### PR TITLE
color to coordinate is highly improved, but still slow

### DIFF
--- a/src/data_getters/mountains.py
+++ b/src/data_getters/mountains.py
@@ -9,7 +9,7 @@ from location_handler import cor_to_crs, displace_camera
 from tools.exif import get_exif_data
 from tools.debug import p_i, p_line
 from tools.file_handling import get_files, tui_select
-from tools.types import Location, Mountain
+from tools.types import Location, Mountain, MountainBounds
 from operator import attrgetter
 from osgeo import gdal
 
@@ -92,7 +92,11 @@ def read_mountain_gpx(gpx_path):
         return []
     gpx = gpxpy.parse(gpx_file)
     mountains = [
-        Mountain(i.name, Location(i.latitude, i.longitude, i.elevation))
+        Mountain(
+            i.name,
+            Location(i.latitude, i.longitude, i.elevation),
+            MountainBounds(i.latitude, i.longitude),
+        )
         for i in gpx.waypoints
     ]
     return mountains

--- a/src/dem.py
+++ b/src/dem.py
@@ -109,7 +109,7 @@ def render_dem(panorama_path, mode, mountains):
             pov_mode = "gradient"
             out_filename = f"{folder}{ds_name}-render-{pov_mode}.png"
             gradient_render = os.path.isfile("%s" % out_filename)
-            gradient_path = create_color_gradient_image(dem_file)
+            gradient_path, gradient = create_color_gradient_image(dem_file)
             if not gradient_render:
                 pov = primary_pov(
                     dem_file, raster_data, texture_path=gradient_path, mode=pov_mode

--- a/src/dem.py
+++ b/src/dem.py
@@ -4,7 +4,6 @@ import subprocess
 from data_getters.mountains import get_mountain_data
 from tools.debug import check_file_type, p_e, p_i, p_line
 from location_handler import (
-    get_min_max_coordinates,
     plot_to_map,
     get_mountains_in_sight,
     get_raster_data,
@@ -109,7 +108,7 @@ def render_dem(panorama_path, mode, mountains):
             pov_mode = "gradient"
             out_filename = f"{folder}{ds_name}-render-{pov_mode}.png"
             gradient_render = os.path.isfile("%s" % out_filename)
-            gradient_path, gradient = create_color_gradient_image(dem_file)
+            gradient_path, _ = create_color_gradient_image(dem_file)
             if not gradient_render:
                 pov = primary_pov(
                     dem_file, raster_data, texture_path=gradient_path, mode=pov_mode
@@ -119,9 +118,21 @@ def render_dem(panorama_path, mode, mountains):
                     pf.write(pov)
                 execute_pov(params)
             locs = colors_to_coordinates(ds_name, gradient_path, folder, dem_file)
-            mountains_in_sight = get_mountains_in_sight(dem_file, locs, mountains)
+
+            radius = 150  # in meters
+            mountains_in_sight = get_mountains_in_sight(
+                dem_file, locs, mountains, radius=radius
+            )
             plot_filename = "%s%s.html" % (folder, panorama_filename)
-            plot_to_map(mountains_in_sight, coordinates, plot_filename, dem_file)
+            plot_to_map(
+                mountains_in_sight,
+                coordinates,
+                plot_filename,
+                dem_file,
+                locs=locs,
+                mountains=mountains,
+                mountain_radius=radius,
+            )
         else:
             return
     stats = [

--- a/src/location_handler.py
+++ b/src/location_handler.py
@@ -21,8 +21,6 @@ EARTH_RADIUS = 6378.1
 
 def get_raster_data(dem_file, coordinates):
     ds_raster = rasterio.open(dem_file)
-    # get resolution (points per square meter)
-    resolution = ds_raster.transform[0]
     # get coordinate reference system
     crs = int(ds_raster.crs.to_authority()[1])
     # convert lat_lon to grid coordinates in the interval [0, 1]

--- a/src/tools/color_map.py
+++ b/src/tools/color_map.py
@@ -1,5 +1,4 @@
 import os
-from alive_progress.core.progress import alive_bar
 import cv2
 import numpy as np
 import pickle
@@ -8,10 +7,8 @@ import subprocess
 from osgeo import gdal
 from data_getters.mountains import read_hike_gpx
 from location_handler import convert_single_coordinate_pair, cor_to_crs, crs_to_cor
-from image_manipulations import resizer
 from tools.types import TextureBounds
 from tools.debug import p_i
-from collections import defaultdict
 
 
 # stolen from

--- a/src/tools/color_map.py
+++ b/src/tools/color_map.py
@@ -11,17 +11,11 @@ from location_handler import convert_single_coordinate_pair, cor_to_crs, crs_to_
 from image_manipulations import resizer
 from tools.types import TextureBounds
 from tools.debug import p_i
+from collections import defaultdict
 
 
 # stolen from
 # https://www.cocyer.com/python-pillow-generate-gradient-image-with-numpy/
-
-
-def get_gradient_2d(start, stop, width, height, is_horizontal):
-    if is_horizontal:
-        return np.tile(np.linspace(start, stop, width), (height, 1))
-    else:
-        return np.tile(np.linspace(start, stop, height), (width, 1)).T
 
 
 def get_gradient_3d(
@@ -32,7 +26,11 @@ def get_gradient_3d(
     for i, (start, stop, is_horizontal) in enumerate(
         zip(upper_left_color, lower_right_color, is_horizontal_list)
     ):
-        result[:, :, i] = get_gradient_2d(start, stop, width, height, is_horizontal)
+        result[:, :, i] = (
+            np.tile(np.linspace(start, stop, width), (height, 1))
+            if is_horizontal
+            else np.tile(np.linspace(start, stop, height), (width, 1)).T
+        )
     return result
 
 
@@ -50,7 +48,7 @@ def create_color_gradient_image(dem_file):
     )
     img = cv2.cvtColor(np.uint8(gradient * 255), cv2.COLOR_BGR2RGB)
     cv2.imwrite(gradient_path, img)
-    return gradient_path
+    return gradient_path, gradient
 
 
 def load_pickle(path):
@@ -175,57 +173,30 @@ def colors_to_coordinates(
 ):
     p_i(f"Finding all visible coordinates in {ds_name}-render-gradient.png")
     render_path = f"{folder}{ds_name}-render-gradient.png"
-    coordinates_seen_in_render_path = "%s/coordinates/coordinates.pkl" % folder
-    pickle_exists = os.path.isfile("%s" % coordinates_seen_in_render_path)
-    gradient = cv2.cvtColor(cv2.imread(gradient_path), cv2.COLOR_BGR2RGB)
-    if not pickle_exists:
-        image = cv2.cvtColor(cv2.imread(render_path), cv2.COLOR_BGR2RGB)
-        image = resizer(image, im_width=200)
-        unique_colors = np.unique(image.reshape(-1, image.shape[2]), axis=0)[2:]
-        l_ = len(unique_colors)
-        color_coordinates = dict()
-        div = 2
-        with alive_bar(int(l_ / div)) as bar:
-            # TODO: Make this more efficient
-            for i in range(0, l_, div):
-                color = unique_colors[i]
-                indices = np.where(np.all(gradient == color, axis=2))
-                if len(indices[0]) > 0:
-                    coordinates = zip(indices[0], indices[1])
-                    unique_coordinates = list(set(list(coordinates)))
-                    color_coordinates[rgb_to_hex(color)] = unique_coordinates
-                bar()
-        try:
-            os.mkdir("%s/coordinates" % folder)
-        except FileExistsError:
-            pass
-        with open(coordinates_seen_in_render_path, "wb") as f:
-            pickle.dump(color_coordinates, f)
-    else:
-        color_coordinates = load_pickle(coordinates_seen_in_render_path)
+    image = cv2.cvtColor(cv2.imread(render_path), cv2.COLOR_BGR2RGB)
+    unique_colors = np.unique(image.reshape(-1, image.shape[2]), axis=0)[2:]
+    unique_colors = [rgb_to_hex(i) for i in unique_colors]
+    color_coordinates = dict()
+    g = cv2.cvtColor(cv2.imread(gradient_path), cv2.COLOR_BGR2RGB)
+
+    h, w, _ = g.shape
+    p_i("Computing pixel/coordinate pairs for gradient image")
+    img_dict = {rgb_to_hex(g[i, j]): (i, j) for i in range(h) for j in range(w)}
+
+    p_i("Getting pixel coordinates for colors in render")
+    color_coordinates = {i: img_dict[i] for i in unique_colors if i in img_dict}
+
     latlon_color_coordinates = []
     ds_raster = rasterio.open(dem_file)
     h = ds_raster.read(1)
     crs = int(ds_raster.crs.to_authority()[1])
-    use_all_coordinates = False
-    for coordinates in color_coordinates.values():
-        if use_all_coordinates:
-            for coordinate in coordinates:
-                x, y = coordinate
-                px, py = ds_raster.xy(x, y)
-                height = h[x][y]
-                latlon = crs_to_cor(crs, px, py, height)
-                latlon_color_coordinates.append(
-                    latlon
-                ) if height >= min_ele and height <= max_ele else None
-        else:
-            x, y = coordinates[len(coordinates) // 2]
-            px, py = ds_raster.xy(x, y)
-            height = h[x][y]
-            latlon = crs_to_cor(crs, px, py, height)
-            latlon_color_coordinates.append(
-                latlon
-            ) if height >= min_ele and height <= max_ele else None
+
+    for x, y in color_coordinates.values():
+        px, py = ds_raster.xy(x, y)
+        height = h[x][y]
+        latlon_color_coordinates.append(
+            crs_to_cor(crs, px, py, height)
+        ) if height >= min_ele and height <= max_ele else None
     return latlon_color_coordinates
 
 

--- a/src/tools/color_map.py
+++ b/src/tools/color_map.py
@@ -176,12 +176,13 @@ def colors_to_coordinates(
     image = cv2.cvtColor(cv2.imread(render_path), cv2.COLOR_BGR2RGB)
     unique_colors = np.unique(image.reshape(-1, image.shape[2]), axis=0)[2:]
     unique_colors = [rgb_to_hex(i) for i in unique_colors]
-    color_coordinates = dict()
     g = cv2.cvtColor(cv2.imread(gradient_path), cv2.COLOR_BGR2RGB)
 
     h, w, _ = g.shape
     p_i("Computing pixel/coordinate pairs for gradient image")
-    img_dict = {rgb_to_hex(g[i, j]): (i, j) for i in range(h) for j in range(w)}
+    img_dict = {
+        rgb_to_hex(g[i, j]): (i, j) for i in range(0, h, 3) for j in range(0, w, 3)
+    }
 
     p_i("Getting pixel coordinates for colors in render")
     color_coordinates = {i: img_dict[i] for i in unique_colors if i in img_dict}

--- a/src/tools/types.py
+++ b/src/tools/types.py
@@ -1,6 +1,9 @@
 import operator
 from dataclasses import dataclass
 
+import location_handler
+from pygeodesy.sphericalNvector import LatLon
+
 
 @dataclass
 class Location:
@@ -9,10 +12,50 @@ class Location:
     elevation: float = 0.0
 
 
+# Might delete this later, wasn't use for it
+@dataclass
+class MountainBounds:
+    bounds = ()
+
+    def __init__(self, lat, lon):
+        displaced_coordinates = [
+            location_handler.displace_camera(lat, lon, degrees=i, distance=0.15)
+            for i in range(0, 360 + 1, 45)
+        ]
+        self.bounds = (
+            LatLon(*displaced_coordinates[0]),
+            LatLon(*displaced_coordinates[1]),
+            LatLon(*displaced_coordinates[2]),
+            LatLon(*displaced_coordinates[3]),
+            LatLon(*displaced_coordinates[4]),
+            LatLon(*displaced_coordinates[5]),
+            LatLon(*displaced_coordinates[6]),
+            LatLon(*displaced_coordinates[7]),
+        )
+
+    def get_bounds(self):
+        return self.bounds
+
+    def __eq__(self, other):
+        return (
+            self.min_latitude == other.min_latitude
+            and self.max_latitude == other.max_latitude
+            and self.min_longitude == other.min_longitude
+            and self.max_longitude == other.max_longitude
+        )
+
+    def __hash__(self):
+        return hash(str(self))
+
+    def __cmp__(self, other):
+        return operator.eq((str(self), str(other)))
+
+
 @dataclass
 class Mountain:
     name: str
     location: Location
+    bounds: MountainBounds
 
     def __eq__(self, other):
         return self.name == other.name


### PR DESCRIPTION
Color to coordinate mapping has been reduced from a 5-minute runtime on the largest datasets to just around a minute. Still way too slow, but at least a major improvement compared to earlier.

Also, the Folium map presentation of the retreived mountains in sight has been updated to show the radius around the mountain tops, and all sample points retreived from the color mapping. Also shows the bounds of the raster being used as a red square on the map.

Example:
<img width="588" alt="Screenshot 2021-12-17 at 13 56 33" src="https://user-images.githubusercontent.com/31273371/146548832-f91b97b7-3c7a-4d19-981d-892ddee27485.png">
<img width="675" alt="Screenshot 2021-12-17 at 13 57 57" src="https://user-images.githubusercontent.com/31273371/146548849-10f29142-3c05-47c5-8397-99e90c90d9b9.png">

Closes #32 

