### PR TITLE
Mountain yaw is fixed, improvements to height map coloring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -318,3 +318,4 @@ panorama*.html
 compared_ds/
 *.txt
 src/static/*.html
+src/static/foliums/*.html

--- a/src/image_handling.py
+++ b/src/image_handling.py
@@ -51,8 +51,8 @@ def get_image_description(file_path):
         im = exif.Image(image_file)
         image_file.close()
     try:
-        return im.image_description
-    except AttributeError:
+        return im.user_comment
+    except (UnicodeDecodeError, AttributeError):
         return None
 
 
@@ -64,17 +64,11 @@ def write_exif_to_pano(file_path, fov, imdims):
     im.gps_img_direction_ref = "M"
     imdata = {"fov": fov, "imdims": imdims}
     custom_exif = json.dumps(imdata, separators=(",", ":"))
-    im.image_description = custom_exif
+    im.user_comment = custom_exif
     with open("/tmp/exifed.jpg", "wb") as new_image_file:
         new_image_file.write(im.get_file())
         new_image_file.close()
     os.rename("/tmp/exifed.jpg", file_path)
-    """ with open(file_path, "rb") as image_file:
-        im = exif.Image(image_file)
-        image_file.close()
-    print(im.gps_img_direction)
-    print(im.gps_img_direction_ref) """
-    print(im.image_description)
 
 
 def vertical_stack_imshow_divider(im1, im2, title="Preview", div_thickness=3):
@@ -278,15 +272,13 @@ def transform_panorama(pano_path, render_path, pano_coords, render_coords):
     }
 
     pts_panorama = np.float32([[x, y] for x, y in pano_coords.values()])
-    # print(f"Pano coords: {pts_panorama}")
     panorama_image = cv2.imread(pano_path)
     pts_render = np.float32([[x, y] for x, y in render_coords.values()])
-    # print(f"Render coords: {pts_render}")
     render_image = cv2.imread(render_path)
     render_width = render_image.shape[1]
 
     if len(pano_coords) != len(render_coords):
-        return
+        return False, False
 
     prev_x_coord = 0
     shift_coords = False
@@ -296,8 +288,6 @@ def transform_panorama(pano_path, render_path, pano_coords, render_coords):
             pts_render[i][0] = x + render_width
             shift_coords = True
         prev_x_coord = x
-
-    # print(f"Render coords shifted: {pts_render}")
 
     render_image = cv2.hconcat([render_image, render_image])
 
@@ -341,31 +331,25 @@ def transform_panorama(pano_path, render_path, pano_coords, render_coords):
 
     im_overlay = cv2.add(bg_render, fg_panorama)
 
-    ub_l, ub_r, lb_r, lb_l = warped_bbox[0]
-
-    print(f"ub_l: {ub_l}, ub_r: {ub_r}, lb_r: {lb_r}, lb_l: {lb_l}")
+    ub_l, ub_r, _, _ = warped_bbox[0]
 
     minx = int(ub_l[0])
     maxx = int(ub_r[0])
 
-    render_image2 = cv2.rectangle(
+    """ render_image2 = cv2.rectangle(
         render_image.copy(),
         (minx, 0),
         (maxx, render_image.shape[0]),
         (0, 0, 255, 1),
         5,
     )
-    cv2.imwrite(f"testcrop.png", render_image2)
+    cv2.imwrite(f"testcrop.png", render_image2) """
 
     heading_bound_left, heading_bound_right = get_fov_bounds(render_width, minx, maxx)
 
-    print(f"Min heading: {heading_bound_left}")
-    print(f"Max heading: {heading_bound_right}")
-    print(f"FOV:         {(heading_bound_right-heading_bound_left) % 360}")
-
     pano_filename = pano_path.split("/")[-1].split(".")[0]
-    overlay_path = f"src/static/{pano_filename}-overlay.jpg"
-    ultrawide_render_path = f"src/static/{pano_filename}-ultrawide.jpg"
+    overlay_path = f"src/static/images/{pano_filename}-overlay.jpg"
+    ultrawide_render_path = f"src/static/images/{pano_filename}-ultrawide.jpg"
 
     overlay_crop = im_overlay[0 : im_overlay.shape[0], minx:maxx]
     ultrawide_render_crop = render_image[0 : im_overlay.shape[0], minx:maxx]

--- a/src/location_handler.py
+++ b/src/location_handler.py
@@ -1,11 +1,10 @@
-from math import asin, cos, radians, sin, atan2, degrees, pi
+from math import asin, cos, sin, atan2, degrees, pi
 import numpy as np
 import rasterio
 from tools.converters import (
     convert_coordinates,
-    cor_to_crs,
-    crs_to_cor,
-    crs_to_wgs84,
+    latlon_to_crs,
+    crs_to_latlon,
     get_earth_radius,
 )
 from tools.debug import p_i, p_e, p_line, p_s
@@ -16,7 +15,7 @@ from numpy import arctan2, sin, cos, degrees
 import cv2
 from operator import attrgetter
 
-from tools.types import Location, Location3D
+from tools.types import Location3D
 
 
 def get_raster_data(dem_file, coordinates):
@@ -77,7 +76,7 @@ def find_visible_coordinates_in_render(ds_name, gradient_path, render_path, dem_
         s_x, s_y = round(x * x_), round(y * y_)
         px, py = ds_raster.xy(s_x, s_y)
         height = ds_raster_height_band[s_x, s_y]
-        latlon_color_coordinates.append(crs_to_cor(crs, px, py, height))
+        latlon_color_coordinates.append(crs_to_latlon(crs, px, py, height))
     return latlon_color_coordinates
 
 
@@ -163,17 +162,17 @@ def get_min_max_coordinates(dem_file):
 def get_raster_bounds(dem_file, lat_lon=True):
     ds_raster = rasterio.open(dem_file)
     bounds = ds_raster.bounds
-
-    def format_coords(coords):
-        return [c[0] for c in coords]
+    crs = int(ds_raster.crs.to_authority()[1])
 
     if lat_lon:
-        lower_left = format_coords(crs_to_wgs84(ds_raster, bounds.left, bounds.bottom))
-        upper_left = format_coords(crs_to_wgs84(ds_raster, bounds.left, bounds.top))
-        upper_right = format_coords(crs_to_wgs84(ds_raster, bounds.right, bounds.top))
-        lower_right = format_coords(
-            crs_to_wgs84(ds_raster, bounds.right, bounds.bottom)
-        )
+        ll = crs_to_latlon(crs, bounds.left, bounds.bottom)
+        lower_left = ll.latitude, ll.longitude
+        ul = crs_to_latlon(crs, bounds.left, bounds.top)
+        upper_left = ul.latitude, ul.longitude
+        ur = crs_to_latlon(crs, bounds.right, bounds.top)
+        upper_right = ur.latitude, ur.longitude
+        lr = crs_to_latlon(crs, bounds.right, bounds.bottom)
+        lower_right = lr.latitude, lr.longitude
     else:
         lower_left = (bounds.left, bounds.bottom)
         upper_left = (bounds.left, bounds.top)
@@ -230,14 +229,13 @@ def get_distance_between_locations(loc1, loc2):
 
 
 def find_angle_between_three_locations(loc1, loc2, loc3):
-    print(loc1, loc2, loc3)
     a1 = atan2(loc3.GetX() - loc2.GetX(), loc3.GetY() - loc2.GetY())
     a2 = atan2(loc3.GetX() - loc1.GetX(), loc3.GetY() - loc1.GetY())
     return degrees(a1 - a2)
 
 
 def get_mountain_3d_location(camera_location, viewing_direction, crs, mountains):
-    loc1 = cor_to_crs(
+    loc1 = latlon_to_crs(
         crs,
         *displace_camera(
             camera_location.latitude,
@@ -246,7 +244,7 @@ def get_mountain_3d_location(camera_location, viewing_direction, crs, mountains)
             distance=1.0,
         ),
     )
-    loc3 = cor_to_crs(crs, camera_location.latitude, camera_location.longitude)
+    loc3 = latlon_to_crs(crs, camera_location.latitude, camera_location.longitude)
 
     for mountain in mountains.values():
         d = get_distance_between_locations(camera_location, mountain.location)
@@ -256,12 +254,8 @@ def get_mountain_3d_location(camera_location, viewing_direction, crs, mountains)
         h = (d ** 2 + diff ** 2) ** 0.5
         pitch = degrees(asin(diff / h))
         m = mountain.location
-        loc2 = cor_to_crs(crs, m.latitude, m.longitude)
+        loc2 = latlon_to_crs(crs, m.latitude, m.longitude)
         yaw = find_angle_between_three_locations(loc1, loc2, loc3)
-        print(f"Mountain: {mountain.name}")
-        print(f"Pitch: {pitch}")
-        print(f"Yaw: {yaw}")
-        # deg = get_bearing(loc3.latitude, loc3.longitude, loc2.latitude, loc2.longitude)
 
         mountain.set_location_in_3d(Location3D(yaw=yaw, pitch=pitch, distance=d))
 

--- a/src/povs.py
+++ b/src/povs.py
@@ -134,15 +134,24 @@ def primary_pov(
                 pigment {
                     gradient y
                     color_map {
-                        [0.0001 color rgb<0.63, 0.62, 0.46>]
-                        [0.0015 color rgb<0.47, 0.33, 0.23>]
-                        [0.0060 color rgb<0.70, 0.62, 0.57>]
-                        [0.0105 color rgb<0.58, 0.46, 0.38>]
-                        [0.0150 color rgb<0.70, 0.62, 0.57>]
-                        [0.0195 color rgb<0.58, 0.46, 0.38>]
-                        [0.0240 color rgb<0.70, 0.62, 0.57>]
-                        [0.0285 color rgb<0.58, 0.46, 0.38>]
-                        [0.0320 color rgb<0.70, 0.62, 0.57>]
+                        // [0.00000000000001 color rgb<0.42, 0.56, 0.41>] // highland (green, more saturated)
+                        // [0.0002 color rgb<0.50, 0.57, 0.41>] // highland (green)
+                        // [0.0005 color rgb<0.57, 0.55, 0.41>] // avocado (green)
+                        // [0.0015 color rgb<0.58, 0.46, 0.38>] // domino (brown)
+                        // [0.0060 color rgb<0.47, 0.33, 0.23>] // shingle fawn (brown)
+                        // [0.0130 color rgb<0.57, 0.55, 0.41>] // avocado (green)
+                        // [0.0160 color rgb<0.47, 0.33, 0.23>] // shingle fawn (brown)
+                        // [0.0190 color rgb<0.50, 0.43, 0.36>] // donkey brown (brown)
+                        // [0.0220 color rgb<0.58, 0.46, 0.38>] // domino (brown)
+                        // [0.0250 color rgb<0.70, 0.62, 0.57>] // del rio (brown)
+                        [0.0001 color rgb<0.01, 0.40, 0.26>] // darthmouth green
+                        [0.0035 color rgb<0.89, 0.79, 0.45>] // chenin
+                        [0.0070 color rgb<0.78, 0.58, 0.27>] // tussock
+                        [0.0105 color rgb<0.62, 0.16, 0.00>] // totem pole
+                        [0.0140 color rgb<0.60, 0.60, 0.60>] // aluminum
+                        [0.0200 color rgb<0.78, 0.58, 0.27>] // tussock
+                        [0.0235 color rgb<0.62, 0.16, 0.00>] // totem pole
+                        [0.0270 color rgb<0.60, 0.60, 0.60>] // aluminum
                         [MAXMOUNTAIN color White]
                     }
                 }

--- a/src/povs.py
+++ b/src/povs.py
@@ -30,7 +30,6 @@ def primary_pov(
 
     if fov:
         fov = get_fov(fov)
-        print("FOV:", fov)
     else:
         fov = 360
 
@@ -118,9 +117,9 @@ def primary_pov(
             pigment {
                 gradient y
                 color_map {
-                    [0.4 color rgb<1 1 1>]
-                    [0.8 color rgb<0.1,0.25,0.75>]
-                    [1 color rgb<0.1,0.25,0.75>]
+                    [0.25 color rgb<0.95, 0.98, 0.99>]
+                    [0.7 color rgb<0.54, 0.76, 0.85>]
+                    [1 color rgb<0.23,0.60,0.74>]
                 }
                 scale 2
                 translate -1
@@ -135,7 +134,15 @@ def primary_pov(
                 pigment {
                     gradient y
                     color_map {
-                        [0.0000000000000000000001 color BakersChoc]
+                        [0.0001 color rgb<0.63, 0.62, 0.46>]
+                        [0.0015 color rgb<0.47, 0.33, 0.23>]
+                        [0.0060 color rgb<0.70, 0.62, 0.57>]
+                        [0.0105 color rgb<0.58, 0.46, 0.38>]
+                        [0.0150 color rgb<0.70, 0.62, 0.57>]
+                        [0.0195 color rgb<0.58, 0.46, 0.38>]
+                        [0.0240 color rgb<0.70, 0.62, 0.57>]
+                        [0.0285 color rgb<0.58, 0.46, 0.38>]
+                        [0.0320 color rgb<0.70, 0.62, 0.57>]
                         [MAXMOUNTAIN color White]
                     }
                 }
@@ -185,7 +192,8 @@ def primary_pov(
                 DEPTHTEXTURE
                 translate CAMERAPOS
                 #else
-                pigment { color rgb<0.1,0.25,0.75> }
+                pigment { color rgb<0.16, 0.41, 0.52> }
+                
                 finish {
                     reflection 0 ambient 1 diffuse 0 specular 0
                 }

--- a/src/run.py
+++ b/src/run.py
@@ -9,7 +9,7 @@ from image_handling import (
     reduce_filesize,
     transform_panorama,
 )
-from renderer import mountain_lookup, render_dem, render_height
+from renderer import mountain_lookup, render_height
 from tools.file_handling import make_folder
 from PIL import Image
 
@@ -17,6 +17,8 @@ from PIL import Image
 def create_app():
     app = Flask(__name__, static_url_path="/src/static")
     UPLOAD_FOLDER = "src/static/"
+    IMG_UPLOAD_FOLDER = f"{UPLOAD_FOLDER}images/"
+    GPX_UPLOAD_FOLDER = f"{UPLOAD_FOLDER}gpx/"
     app.secret_key = "secret key"
     app.config["UPLOAD_FOLDER"] = UPLOAD_FOLDER
     app.config["MAX_CONTENT_LENGTH"] = 30 * 1024 * 1024
@@ -42,10 +44,13 @@ def create_app():
         if request.method == "POST":
             f = request.files["file"]
             filename = secure_filename(f.filename)
-            pano_path = f"{UPLOAD_FOLDER}{filename}"
+            pano_path = f"{IMG_UPLOAD_FOLDER}{filename}"
+            app.logger.info(f"Uploaded {filename}")
             make_folder(UPLOAD_FOLDER)
+            make_folder(IMG_UPLOAD_FOLDER)
             if not os.path.exists(pano_path):
                 f.save(pano_path)
+                app.logger.info(f"Saved {filename}")
                 reduce_filesize(pano_path)
             with Image.open(pano_path) as img:
                 width, _ = img.size
@@ -53,16 +58,20 @@ def create_app():
                     return "<h4>Image is too wide. Must be less than 16384px.</h4>"
                 img.close()
             im_location = get_exif_gps_latlon(pano_path)
+            app.logger.info(im_location)
             if not im_location:
                 return "<h4>Image does not have location data.</h4>"
             session["pano_path"] = pano_path
 
             im_view_direction = get_exif_gsp_img_direction(pano_path)
+            app.logger.info(im_view_direction)
+
             im_description = get_image_description(pano_path)
+            app.logger.info(im_description)
 
             if im_location and im_view_direction and im_description:
                 pano_filename = f"{pano_path.split('/')[-1].split('.')[0]}"
-                render_path = f"{UPLOAD_FOLDER}{pano_filename}-render.png"
+                render_path = f"{IMG_UPLOAD_FOLDER}{pano_filename}-render.png"
                 if os.path.exists(render_path):
                     session["render_path"] = render_path
                     return redirect(url_for("selectgpx"))
@@ -73,9 +82,10 @@ def create_app():
         if request.method == "POST":
             f = request.files["file"]
             filename = secure_filename(f.filename)
-            gpx_path = f"{UPLOAD_FOLDER}{filename}"
-            make_folder(UPLOAD_FOLDER)
+            gpx_path = f"{GPX_UPLOAD_FOLDER}{filename}"
+            make_folder(GPX_UPLOAD_FOLDER)
             f.save(gpx_path)
+            app.logger.info(f"Saved {filename}")
             session["gpx_path"] = gpx_path
             redir_url = "mountains"
             task = "findmtns"
@@ -94,7 +104,9 @@ def create_app():
     @app.route("/rendering")
     def rendering():
         pano_path = session.get("pano_path", None)
+        app.logger.info(f"Pano path: {pano_path}")
         render_path = session.get("render_path", None)
+        app.logger.info(f"Rendering {render_path}")
         render_complete = render_height(pano_path, render_path)
         if render_complete:
             return ("", 204)
@@ -106,7 +118,7 @@ def create_app():
     def spcoords():
         pano_path = session["pano_path"]
         pano_filename = f"{pano_path.split('/')[-1].split('.')[0]}"
-        render_path = f"{UPLOAD_FOLDER}{pano_filename}-render.png"
+        render_path = f"{IMG_UPLOAD_FOLDER}{pano_filename}-render.png"
         session["render_path"] = render_path
         with Image.open(pano_path) as img:
             width, height = img.size
@@ -177,6 +189,8 @@ def create_app():
         transformed_im, ultrawide_render = transform_panorama(
             pano_path, render_path, pano_coords, render_coords
         )
+        if not transformed_im or not ultrawide_render:
+            return "<h4>Transform failed because of an unequal amount of sample points in the panorama and render ...</h4>"
         return render_template(
             "preview_warped.html",
             warped=transformed_im,
@@ -188,7 +202,7 @@ def create_app():
         pano_path = session.get("pano_path", None)
         gpx_path = session.get("gpx_path", None)
         pano_filename = f"{pano_path.split('/')[-1].split('.')[0]}"
-        render_filename = f"{UPLOAD_FOLDER}{pano_filename}-gradient.png"
+        render_filename = f"{IMG_UPLOAD_FOLDER}{pano_filename}-gradient.png"
         mountains_3d = mountain_lookup(pano_path, render_filename, gpx_path)
         hs = hotspots(mountains_3d)
         session["hotspots"] = hs
@@ -199,9 +213,14 @@ def create_app():
         hs = session.get("hotspots", None)
         render_path = session.get("render_path", None)
         pano_path = session.get("pano_path", None)
+        pano_filename = f"{pano_path.split('/')[-1].split('.')[0]}"
         yaw = get_exif_gsp_img_direction(pano_path)
         return render_template(
-            "view_mountains.html", hs=hs, render_path=render_path, yaw=yaw
+            "view_mountains.html",
+            hs=hs,
+            render_path=render_path,
+            yaw=yaw,
+            pano_filename=pano_filename,
         )
 
     """ @app.route("/testing")
@@ -226,9 +245,6 @@ def hotspots(mountains_3d):
             "latitude": loc.latitude,
             "longitude": loc.longitude,
         }
-
-    print(hotspots)
-
     return hotspots
 
 

--- a/src/static/styling/index.css
+++ b/src/static/styling/index.css
@@ -12,6 +12,11 @@
     height: 85vh;
 }
 
+#mountain-overlay {
+    width: 80vw;
+    height: 80vh;
+}
+
 #coordinates {
     background: #e9e9e9;
     width: 100vw;
@@ -153,4 +158,14 @@ div.mountain-tooltip:hover span:after {
     100% {
         transform: rotate(360deg);
     }
+}
+
+#folium-container {
+    width: 100vw;
+    height: 80vh;
+}
+
+#folium-map {
+    width: 80vw;
+    height: 80vh;
 }

--- a/src/static/styling/index.css
+++ b/src/static/styling/index.css
@@ -106,6 +106,10 @@ div.mountain-tooltip:hover span:after {
     margin: 0 50%;
 }
 
+.fill-screen {
+    height: 80vh;
+}
+
 .loader {
     color: #000;
     font-size: 45px;

--- a/src/templates/view_mountains.html
+++ b/src/templates/view_mountains.html
@@ -20,10 +20,37 @@
             href="{{ url_for('static', filename='styling/index.css') }}"
         />
         <script src="{{ url_for('static', filename='scripts/tools.js') }}"></script>
+        <script src="jquery.js"></script>
+        <script>
+            $(function () {
+                $('#folium-map').load(
+                    "{{ url_for('static', filename='foliums/2021-04-17--pic03--Lyderhorn.html') }}"
+                )
+            })
+        </script>
         <title>E2 - View Mountains</title>
     </head>
     <body>
-        <div id="render-preview"></div>
+        <div class="px-4 py-4 my-4 text-center">
+            <h3 class="fw-bold text-start">Mountain Overlay</h3>
+            <div class="p-3 border bg-light">
+                <div class="d-grid d-sm-flex justify-content-sm-center">
+                    <div id="mountain-overlay"></div>
+                </div>
+            </div>
+        </div>
+        <div class="px-4 py-4 my-4 text-center">
+            <h3 class="fw-bold text-start">Interactive Map</h3>
+            <div class="p-3 border bg-light">
+                <div class="d-grid d-sm-flex justify-content-sm-center">
+                    <div id="folium-container">
+            <object
+                id="folium-map"
+                data="src/static/foliums/{{pano_filename}}.html"
+            ></object>
+                </div>
+            </div>
+        </div>
 
         <script>
             const mountains = JSON.parse('{{ hs | tojson | safe }}')
@@ -36,7 +63,7 @@
                 hotSpotDiv.appendChild(span)
                 span.style.width = span.scrollWidth - 20 + 'px'
                 span.style.marginLeft =
-                    -(span.scrollWidth - hotSpotDiv.offsetWidth) / 2 + 'px'
+                    -(span.scrollWidth - hotSpotDiv.offsetWidth) / 2 - 9.5 + 'px'
                 span.style.marginTop = -span.scrollHeight - 12 + 'px'
             }
 
@@ -46,8 +73,10 @@
                     const lat = value.latitude
                     const lon = value.longitude
                     const url = `https://www.google.com/maps/search/${lat},${lon}/`
+                    console.log(value.yaw)
+                    
                     return {
-                        yaw: 180 - (parseFloat(value.yaw) % 360),
+                        yaw: viewDirection + parseFloat(value.yaw),
                         pitch: value.pitch,
                         cssClass: 'custom-hotspot mountain-hotspot',
                         createTooltipArgs: key,
@@ -57,7 +86,7 @@
                 })
             )
 
-            viewer = pannellum.viewer('render-preview', {
+            viewer = pannellum.viewer('mountain-overlay', {
                 type: 'equirectangular',
                 panorama: '{{ render_path }}',
                 autoLoad: true,

--- a/src/templates/view_mountains.html
+++ b/src/templates/view_mountains.html
@@ -73,7 +73,6 @@
                     const lat = value.latitude
                     const lon = value.longitude
                     const url = `https://www.google.com/maps/search/${lat},${lon}/`
-                    console.log(value.yaw)
                     
                     return {
                         yaw: viewDirection + parseFloat(value.yaw),

--- a/src/tools/file_handling.py
+++ b/src/tools/file_handling.py
@@ -9,7 +9,7 @@ import gpxpy.gpx
 import rasterio
 import image_handling
 from location_handler import displace_camera, find_maximums, find_minimums
-from tools.converters import cor_to_crs
+from tools.converters import latlon_to_crs
 from tools.debug import p_i, p_line
 from tools.types import Location, Mountain, MountainBounds
 from osgeo import gdal
@@ -32,7 +32,7 @@ def get_mountain_data(dem_file, panorama_path, gradient=False):
     ds_raster = rasterio.open(dem_file)
     crs = int(ds_raster.crs.to_authority()[1])
 
-    camera_placement_crs = cor_to_crs(crs, camera_lat, camera_lon)
+    camera_placement_crs = latlon_to_crs(crs, camera_lat, camera_lon)
 
     displacement_distance = 15000  # in meters from camera placement
 

--- a/src/tools/texture.py
+++ b/src/tools/texture.py
@@ -5,7 +5,7 @@ import pickle
 import rasterio
 import subprocess
 from osgeo import gdal
-from tools.converters import convert_single_coordinate_pair, cor_to_crs
+from tools.converters import convert_single_coordinate_pair, latlon_to_crs
 from tools.file_handling import read_hike_gpx
 from tools.types import TextureBounds
 from tools.debug import p_i
@@ -67,8 +67,8 @@ def create_route_texture(dem_file, gpx_path, debugging=False):
     mns, minimums, maximums = read_hike_gpx(gpx_path)
     ds_raster = rasterio.open(dem_file)
     crs = int(ds_raster.crs.to_authority()[1])
-    lower_left = cor_to_crs(crs, minimums[0].latitude, minimums[1].longitude)
-    upper_right = cor_to_crs(crs, maximums[0].latitude, maximums[1].longitude)
+    lower_left = latlon_to_crs(crs, minimums[0].latitude, minimums[1].longitude)
+    upper_right = latlon_to_crs(crs, maximums[0].latitude, maximums[1].longitude)
 
     bbox = (
         lower_left.GetX(),


### PR DESCRIPTION
I knew something was off when calculating the angle between three pairs of `(latitude, longitude)`, so now the `latlon` is converted to `x, y` before the angle calculation is done.

Height map is updated to fit the color palette seen here:
![](https://i.stack.imgur.com/dEGqT.jpg)

So it now looks like this when the mountains in sight are shown as an overlay:
<img width="1420" alt="Screenshot 2022-01-27 at 10 48 03" src="https://user-images.githubusercontent.com/31273371/151335052-07b8e328-5f21-4824-bcf6-39efce130a78.png">

